### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 
 # Cypress test videos
 cypress/videos/
+cypress/downloads/downloads.html

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,6 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  transform: rotate(180deg);
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,5 +139,7 @@
     display: flex;
   }
 
-  transform: rotate(180deg);
+  &.isCollapsed {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,7 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={isSidebarCollapsed ? styles.collapseMenuItem : ""}
             />
           </ul>
         </nav>

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={isSidebarCollapsed ? styles.collapseMenuItem : ""}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
When the sidebar navigation is collapsed the arrow of the “Collapse” button should point to the right.