### PR TITLE
Projects: separator line inside card is too thick

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
The separator line in the project cards should match the design.

Existing separator was 3px but the design calls for 1px.