### PR TITLE
Support button should open the user’s mail app

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -42,6 +42,23 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    it("support button opens the user's mail app", () => {
+      // Stub window.open
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("windowOpen");
+      });
+
+      // Click the support button
+      cy.get("nav").contains("Support").click();
+
+      // Check that window.open was called with the correct arguments
+      cy.get("@windowOpen").should(
+        "be.calledWith",
+        "mailto:support@prolog-app.com?subject=Support Request: ",
+        "_self",
+      );
+    });
   });
 
   context("mobile resolution", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,12 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support Request: ",
+                  "_self",
+                )
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Clicking the “Support” button in the sidebar navigation should open the user’s email app.