### PR TITLE
Fix wrong logo when switching to mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -50,9 +50,11 @@
 
 .logo {
   width: 7.375rem;
+  content: url("/icons/logo-large.svg");
 
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
+    content: unset;
   }
 }
 


### PR DESCRIPTION
On mobile devices, the header should always show the large logo.