### PR TITLE
Add error screen to project list

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -28,6 +28,31 @@ describe("Project List", () => {
       cy.get("img[alt='Loading']").should("not.exist");
     });
 
+    it("shows error dialog after API error", () => {
+      // Simulates a network error
+      cy.intercept("GET", "https://prolog-api.profy.dev/project", {
+        forceNetworkError: true,
+      }).as("getNetworkFailure");
+
+      // open projects page
+      cy.visit("http://localhost:3000/dashboard");
+      cy.wait("@getNetworkFailure");
+
+      // Alert is visible
+      cy.get("img[alt='alert']").should("be.visible");
+
+      cy.intercept("GET", "https://prolog-api.profy.dev/project", {
+        fixture: "projects.json",
+      }).as("getProjects");
+
+      // Click retry button
+      cy.get("img[alt='retry']").should("be.visible").click();
+      cy.wait("@getProjects");
+
+      // Retry should load page
+      cy.get("main").find("ul");
+    });
+
     it("renders the projects", () => {
       // wait for request to resolve
       cy.wait("@getProjects");

--- a/features/projects/api/use-get-projects.tsx
+++ b/features/projects/api/use-get-projects.tsx
@@ -3,5 +3,8 @@ import { getProjects } from "@api/projects";
 import type { Project } from "@api/projects.types";
 
 export function useGetProjects() {
-  return useQuery<Project[], Error>(["projects"], getProjects);
+  return useQuery<Project[], Error>(["projects"], getProjects, {
+    keepPreviousData: true,
+    retry: false,
+  });
 }

--- a/features/projects/components/project-error/index.ts
+++ b/features/projects/components/project-error/index.ts
@@ -1,0 +1,1 @@
+export { ProjectError } from "./project-error";

--- a/features/projects/components/project-error/project-error.module.scss
+++ b/features/projects/components/project-error/project-error.module.scss
@@ -1,0 +1,34 @@
+@use "@styles/color";
+@use "@styles/font";
+@use "@styles/space";
+
+.alertBox {
+  display: flex;
+  padding: 1rem;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid color.$error-300;
+  background: color.$error-25;
+}
+
+.alertCircle {
+  color: color.$error-600;
+}
+
+.errorMsg {
+  flex: 1;
+  color: color.$error-700;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.25rem;
+}
+
+.retryBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  color: color.$error-700;
+  cursor: pointer;
+}

--- a/features/projects/components/project-error/project-error.tsx
+++ b/features/projects/components/project-error/project-error.tsx
@@ -1,0 +1,28 @@
+import styles from "./project-error.module.scss";
+
+type ProjectErrorProps = {
+  refetch: () => void;
+};
+
+export function ProjectError(props: ProjectErrorProps) {
+  const { refetch } = props;
+
+  return (
+    <div className={styles.alertBox}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        className={styles.alertCircle}
+        src="/icons/alert-circle.svg"
+        alt="alert"
+      />
+      <div className={styles.errorMsg}>
+        There was a problem while loading the project data
+      </div>
+      <div className={styles.retryBtn} onClick={refetch}>
+        Try again
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/icons/arrow-right.svg" alt="retry" />
+      </div>
+    </div>
+  );
+}

--- a/features/projects/components/project-list/project-list.tsx
+++ b/features/projects/components/project-list/project-list.tsx
@@ -1,9 +1,10 @@
 import { ProjectCard } from "../project-card";
+import { ProjectError } from "../project-error";
 import { useGetProjects } from "../../api/use-get-projects";
 import styles from "./project-list.module.scss";
 
 export function ProjectList() {
-  const { data, isLoading, isError, error } = useGetProjects();
+  const { data, isLoading, isError, error, refetch } = useGetProjects();
 
   if (isLoading) {
     return (
@@ -20,7 +21,8 @@ export function ProjectList() {
 
   if (isError) {
     console.error(error);
-    return <div>Error: {error.message}</div>;
+
+    return <ProjectError refetch={refetch} />;
   }
 
   return (

--- a/public/icons/alert-circle.svg
+++ b/public/icons/alert-circle.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="alert-circle" clip-path="url(#clip0_644_24329)">
+<path id="Icon" d="M9.99999 6.66663V9.99996M9.99999 13.3333H10.0083M18.3333 9.99996C18.3333 14.6023 14.6024 18.3333 9.99999 18.3333C5.39762 18.3333 1.66666 14.6023 1.66666 9.99996C1.66666 5.39759 5.39762 1.66663 9.99999 1.66663C14.6024 1.66663 18.3333 5.39759 18.3333 9.99996Z" stroke="#D92D20" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_644_24329">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/arrow-right.svg
+++ b/public/icons/arrow-right.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="arrow-right">
+<path id="Icon" d="M4.16669 10.0001H15.8334M15.8334 10.0001L10 4.16675M15.8334 10.0001L10 15.8334" stroke="#B42318" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>


### PR DESCRIPTION
Error dialog is shown when the projects fetch fails and a button to allow the user to retry the fetch is shown.