### PR TITLE
“View issues” link should direct to issues page with pre-selected project filter

### DIFF
--- a/cypress/fixtures/issues-ml.json
+++ b/cypress/fixtures/issues-ml.json
@@ -1,0 +1,11 @@
+{
+  "items": [],
+  "meta": {
+    "currentPage": 1,
+    "limit": 10,
+    "totalItems": 0,
+    "totalPages": 0,
+    "hasPreviousPage": false,
+    "hasNextPage": false
+  }
+}

--- a/cypress/fixtures/projects.json
+++ b/cypress/fixtures/projects.json
@@ -4,7 +4,7 @@
     "numIssues": 73,
     "numEvents24h": 7,
     "status": "error",
-    "name": "Frontend - Web Test",
+    "name": "Frontend - Web",
     "language": "react"
   },
   {

--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -95,21 +95,24 @@ export function IssueList() {
           <button
             className={styles.paginationButton}
             onClick={() => navigateToPage(page - 1)}
-            disabled={page === 1}
+            disabled={!meta?.hasPreviousPage}
           >
             Previous
           </button>
           <button
             className={styles.paginationButton}
             onClick={() => navigateToPage(page + 1)}
-            disabled={page === meta?.totalPages}
+            disabled={!meta?.hasNextPage}
           >
             Next
           </button>
         </div>
         <div className={styles.pageInfo}>
-          Page <span className={styles.pageNumber}>{meta?.currentPage}</span> of{" "}
-          <span className={styles.pageNumber}>{meta?.totalPages}</span>
+          Page{" "}
+          <span className={styles.pageNumber}>
+            {meta?.totalPages ? meta?.currentPage : 0}
+          </span>{" "}
+          of <span className={styles.pageNumber}>{meta?.totalPages}</span>
         </div>
       </div>
     </div>

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -60,7 +60,13 @@ export function ProjectCard({ project }: ProjectCardProps) {
         </div>
       </div>
       <div className={styles.bottomContainer}>
-        <Link href={Routes.issues} className={styles.viewIssuesAnchor}>
+        <Link
+          href={{
+            pathname: Routes.issues,
+            query: { projectName: name },
+          }}
+          className={styles.viewIssuesAnchor}
+        >
           View issues
         </Link>
       </div>


### PR DESCRIPTION
* The issues link opens the issues page with the correct filters pre-set
* Cypress test covering this functionality
* Fix Next/Previous buttons and page numbers with 0 results